### PR TITLE
Use webread instead of web

### DIFF
--- a/tgprintf.m
+++ b/tgprintf.m
@@ -34,4 +34,7 @@ sendstr = ['https://api.telegram.org/bot',token,...
 % send a message   
 ret = webread(sendstr); 
 assert(ret.ok);
+
+% append human readable datetime to results [Set TimeZone value to desired time zone]
+ret.result.datetime=datetime(ret.result.date,'ConvertFrom','posixtime','TimeZone','Asia/Seoul');
 end

--- a/tgprintf.m
+++ b/tgprintf.m
@@ -32,6 +32,6 @@ sendstr = ['https://api.telegram.org/bot',token,...
            '&text=',sendstr];
 
 % send a message   
-ret = web(sendstr); 
-
+ret = webread(sendstr); 
+assert(ret.ok);
 end


### PR DESCRIPTION
Web() opens a matlab browser window, whereas webread() parses the response into a struct.
PR also includes a commit to append human readable date & time.